### PR TITLE
Fix GitHub link to use correct branch name

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -98,7 +98,7 @@
             {%- if header %}
               <a
                 class="main__contribute"
-                href="https://github.com/web-padawan/webcomponents.today/edit/master/content/{{ page.fileSlug }}/{{ page.fileSlug }}.11tydata.js"
+                href="https://github.com/web-padawan/webcomponents.today/edit/main/content/{{ page.fileSlug }}/{{ page.fileSlug }}.11tydata.js"
               >
                 Edit this page on GitHub
               </a>


### PR DESCRIPTION
## Description

The `master` branch has been renamed to `main` so the link needs to be updated.