### PR TITLE
Update RSS feed template to only list posts

### DIFF
--- a/content/feed.njk
+++ b/content/feed.njk
@@ -26,7 +26,7 @@
     <name>{{ metadata.author.name }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
-  {%- for post in collections.all | reverse %}
+  {%- for post in collections.post | reverse %}
   {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
   <entry>
     <title>{{ post.data.title }}</title>


### PR DESCRIPTION
## Description

The RSS feed was incorrectly configured to list all entries. Changed it to only list posts to actually make sense.