### PR TITLE
Move Testing Helpers to new category in Ecosystem

### DIFF
--- a/content/testing-helpers/index.njk
+++ b/content/testing-helpers/index.njk
@@ -1,0 +1,7 @@
+---
+layout: layout
+title: Testing Helpers
+tags: ecosystem
+eleventyNavigation:
+  key: Testing Helpers
+---

--- a/content/testing-helpers/testing-helpers.11tydata.js
+++ b/content/testing-helpers/testing-helpers.11tydata.js
@@ -1,0 +1,67 @@
+module.exports = {
+  url: "testing-helpers",
+  header: "Testing Helpers",
+  description: "Libraries, tools and plugins that make testing Custom Elements and Shadow DOM easier.",
+  items: [
+    {
+      url: "https://github.com/simonireilly/cypress-lit",
+      title: "cypress-lit",
+      thumbnail: "simon-reilly.jpeg",
+      quote: "Test your Lit elements and native web components in Cypress with all the modern browsers.",
+    },
+    {
+      url: "https://github.com/webdriverio/query-selector-shadow-dom",
+      title: "query-selector-shadow-dom",
+      thumbnail: "wdio.png",
+      quote: "Pierce Shadow DOM roots without knowing the path through nested shadow roots for automated testing.",
+    },
+    {
+      url: "https://github.com/salesforce/lwc-test",
+      title: "Lightning Web Components Testing Repository",
+      thumbnail: "salesforce.svg",
+      quote: "Testing utilities for Lightning Web Components, related examples and documentation.",
+    },
+    {
+      url: "https://open-wc.org/docs/testing/testing-package/",
+      title: "Open Web Components: Testing",
+      thumbnail: "open-wc.png",
+      quote: "Opinionated package that combines and configures testing libraries.",
+    },
+    {
+      url: "https://github.com/yuki24/capybara-shadowdom",
+      title: "Shadow DOM support for Capybara",
+      thumbnail: "yuki-nishijima.jpeg",
+      quote: "A Ruby gem that adds basic support for the Shadow DOM to Capybara.",
+    },
+    {
+      url: "https://github.com/sukgu/shadow-automation-selenium",
+      title: "Shadow root DOM automation using Selenium",
+      thumbnail: "sukgu.png",
+      quote: "Plugin for automation of multi-level shadow DOM using Java Selenium.",
+    },
+    {
+      url: "https://github.com/KonnorRogers/shadow-dom-testing-library",
+      title: "shadow-dom-testing-library",
+      thumbnail: "konnor-rogers.jpeg",
+      quote: "An extension f of dom-testing-library to provide hooks into the shadow DOM.",
+    },
+    {
+      url: "https://github.com/43081j/shadow-dom-utils",
+      title: "shadow-dom-utils",
+      thumbnail: "james-garbutt.jpeg",
+      quote: "A set of utilities for dealing with shadow DOM, primarily for test environment.",
+    },
+    {
+      url: "https://github.com/vaadin/testing-helpers",
+      title: "@vaadin/testing-helpers",
+      thumbnail: "vaadin.png",
+      quote: "A set of common testing helpers used for developing Vaadin web components.",
+    },
+    {
+      url: "https://github.com/salesforce/wdio-shadowdom-service",
+      title: "wdio-shadowdom-service",
+      thumbnail: "salesforce.svg",
+      quote: "Plugin for WebDriverIO that makes CSS selectors transparently work with the shadow DOM.",
+    },
+  ],
+};

--- a/content/testing-solutions/testing-solutions.11tydata.js
+++ b/content/testing-solutions/testing-solutions.11tydata.js
@@ -10,22 +10,10 @@ module.exports = {
       quote: "How to run component tests for a Lit web component with Cypress.",
     },
     {
-      url: "https://github.com/simonireilly/cypress-lit",
-      title: "cypress-lit",
-      thumbnail: "simon-reilly.jpeg",
-      quote: "Test your Lit elements and native web components in Cypress with all the modern browsers.",
-    },
-    {
       url: "https://open-wc.org/guides/developing-components/testing/",
       title: "Developing Components: Testing",
       thumbnail: "open-wc.png",
       quote: "Using @web/test-runner for testing web components in a real browser.",
-    },
-    {
-      url: "https://github.com/webdriverio/query-selector-shadow-dom",
-      title: "query-selector-shadow-dom",
-      thumbnail: "wdio.png",
-      quote: "Pierce Shadow DOM roots without knowing the path through nested shadow roots for automated testing.",
     },
     {
       url: "https://www.lambdatest.com/blog/shadow-dom-in-selenium/",
@@ -40,40 +28,10 @@ module.exports = {
       quote: "Conquer the Shadow DOM by using few open-source testing frameworks.",
     },
     {
-      url: "https://open-wc.org/docs/testing/testing-package/",
-      title: "Open Web Components: Testing",
-      thumbnail: "open-wc.png",
-      quote: "Opinionated package that combines and configures testing libraries.",
-    },
-    {
-      url: "https://github.com/yuki24/capybara-shadowdom",
-      title: "Shadow DOM support for Capybara",
-      thumbnail: "yuki-nishijima.jpeg",
-      quote: "The capybara-shadowdom gem adds basic support for the Shadow DOM to Capybara.",
-    },
-    {
       url: "https://docs.percy.io/docs/shadow-dom",
       title: "Shadow DOM support in Percy",
       thumbnail: "percy.png",
       quote: "Percy supports capturing Shadow DOM since Percy CLI v1.19.1-alpha.0 version.",
-    },
-    {
-      url: "https://github.com/sukgu/shadow-automation-selenium",
-      title: "Shadow root DOM automation using Selenium",
-      thumbnail: "sukgu.png",
-      quote: "Plugin for automation of multi-level shadow DOM using Java Selenium.",
-    },
-    {
-      url: "https://github.com/KonnorRogers/shadow-dom-testing-library",
-      title: "shadow-dom-testing-library",
-      thumbnail: "konnor-rogers.jpeg",
-      quote: "An extension of dom-testing-library to provide hooks into the shadow DOM.",
-    },
-    {
-      url: "https://github.com/43081j/shadow-dom-utils",
-      title: "shadow-dom-utils",
-      thumbnail: "james-garbutt.jpeg",
-      quote: "A set of utilities for dealing with shadow DOM, primarily for test environment.",
     },
     {
       url: "https://reflect.run/articles/testing-shadow-dom-elements-in-selenium/",
@@ -92,12 +50,6 @@ module.exports = {
       title: "W3C Webdriver conquering automation of Shadow DOM",
       thumbnail: "medium.svg",
       quote: "Overview of the Shadow DOM tree and its interaction with the W3C Webdriver.",
-    },
-    {
-      url: "https://github.com/salesforce/wdio-shadowdom-service",
-      title: "wdio-shadowdom-service",
-      thumbnail: "salesforce.svg",
-      quote: "Plugin for WebDriverIO that makes CSS selectors transparently work with the shadow DOM.",
     },
   ],
 };


### PR DESCRIPTION
## Description

Current "Testing Solutions" page is placed under "Articles" but it also contains links to actual testing helpers.
Moved these links to their own category which will be located in "Ecosystem". Also, added two more links.